### PR TITLE
A stab at creating a themeable decorator

### DIFF
--- a/src/TextField/TextField.jsx
+++ b/src/TextField/TextField.jsx
@@ -5,12 +5,11 @@ import StylePropable from '../mixins/style-propable';
 import Transitions from '../styles/transitions';
 import UniqueId from '../utils/unique-id';
 import EnhancedTextarea from '../enhanced-textarea';
-import DefaultRawTheme from '../styles/raw-themes/light-raw-theme';
-import ThemeManager from '../styles/theme-manager';
 import ContextPure from '../mixins/context-pure';
 import TextFieldHint from './TextFieldHint';
 import TextFieldUnderline from './TextFieldUnderline';
 import warning from 'warning';
+import themeable from '../styles/themeable-decorator';
 
 /**
  * Check if a value is valid to be displayed inside an input.
@@ -28,10 +27,6 @@ const TextField = React.createClass({
     ContextPure,
     StylePropable,
   ],
-
-  contextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
 
   propTypes: {
     children: React.PropTypes.node,
@@ -51,6 +46,7 @@ const TextField = React.createClass({
     hintText: React.PropTypes.node,
     id: React.PropTypes.string,
     inputStyle: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
     multiLine: React.PropTypes.bool,
     onBlur: React.PropTypes.func,
     onChange: React.PropTypes.func,
@@ -71,17 +67,6 @@ const TextField = React.createClass({
     underlineShow: React.PropTypes.bool,
     underlineStyle: React.PropTypes.object,
     value: React.PropTypes.any,
-  },
-
-  //for passing default theme context to children
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
   },
 
   getDefaultProps() {
@@ -121,7 +106,6 @@ const TextField = React.createClass({
       errorText: this.props.errorText,
       hasValue: isValid(props.value) || isValid(props.defaultValue) ||
         (props.valueLink && isValid(props.valueLink.value)),
-      muiTheme: this.context.muiTheme ? this.context.muiTheme : ThemeManager.getMuiTheme(DefaultRawTheme),
     };
   },
 
@@ -129,9 +113,8 @@ const TextField = React.createClass({
     this._uniqueId = UniqueId.generate();
   },
 
-  componentWillReceiveProps(nextProps, nextContext) {
+  componentWillReceiveProps(nextProps) {
     let newState = {};
-    newState.muiTheme = nextContext.muiTheme ? nextContext.muiTheme : this.state.muiTheme;
 
     newState.errorText = nextProps.errorText;
     if (nextProps.children && nextProps.children.props) {
@@ -165,7 +148,7 @@ const TextField = React.createClass({
       backgroundColor,
       hintColor,
       errorColor,
-    } = this.constructor.getRelevantContextKeys(this.state.muiTheme);
+    } = this.constructor.getRelevantContextKeys(this.props.muiTheme);
 
     let styles = {
       root: {
@@ -176,7 +159,7 @@ const TextField = React.createClass({
         display: 'inline-block',
         position: 'relative',
         backgroundColor: backgroundColor,
-        fontFamily: this.state.muiTheme.rawTheme.fontFamily,
+        fontFamily: this.props.muiTheme.rawTheme.fontFamily,
         transition: Transitions.easeOut('200ms', 'height'),
       },
       error: {
@@ -345,7 +328,7 @@ const TextField = React.createClass({
         {floatingLabelTextElement}
         {hintText ?
           <TextFieldHint
-            muiTheme={this.state.muiTheme}
+            muiTheme={this.props.muiTheme}
             show={!(this.state.hasValue || (floatingLabelText && !this.state.isFocused))}
             style={hintStyle}
             text={hintText}
@@ -361,7 +344,7 @@ const TextField = React.createClass({
             errorStyle={errorStyle}
             focus={this.state.isFocused}
             focusStyle={underlineFocusStyle}
-            muiTheme={this.state.muiTheme}
+            muiTheme={this.props.muiTheme}
             style={underlineStyle}
           /> :
           null
@@ -462,4 +445,4 @@ const TextField = React.createClass({
 
 });
 
-export default TextField;
+export default themeable(TextField);

--- a/src/date-picker/date-picker-dialog.jsx
+++ b/src/date-picker/date-picker-dialog.jsx
@@ -7,8 +7,7 @@ import Calendar from './calendar';
 import Dialog from '../dialog';
 import DatePickerInline from './date-picker-inline';
 import FlatButton from '../flat-button';
-import DefaultRawTheme from '../styles/raw-themes/light-raw-theme';
-import ThemeManager from '../styles/theme-manager';
+import themeable from '../styles/themeable-decorator';
 import DateTime from '../utils/date-time';
 
 const DatePickerDialog = React.createClass({
@@ -31,10 +30,7 @@ const DatePickerDialog = React.createClass({
         Dialog,
       ];
     },
-  },
-
-  contextTypes: {
-    muiTheme: React.PropTypes.object,
+    publicMethods: ['show', 'dismiss'],
   },
 
   propTypes: {
@@ -47,6 +43,7 @@ const DatePickerDialog = React.createClass({
     maxDate: React.PropTypes.object,
     minDate: React.PropTypes.object,
     mode: React.PropTypes.oneOf(['portrait', 'landscape']),
+    muiTheme: React.PropTypes.object.isRequired,
     onAccept: React.PropTypes.func,
     onDismiss: React.PropTypes.func,
     onShow: React.PropTypes.func,
@@ -58,17 +55,6 @@ const DatePickerDialog = React.createClass({
      */
     style: React.PropTypes.object,
     wordings: React.PropTypes.object,
-  },
-
-  //for passing default theme context to children
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
   },
 
   getDefaultProps: function() {
@@ -90,15 +76,7 @@ const DatePickerDialog = React.createClass({
   getInitialState() {
     return {
       open: false,
-      muiTheme: this.context.muiTheme ? this.context.muiTheme : ThemeManager.getMuiTheme(DefaultRawTheme),
     };
-  },
-
-  //to update theme inside state whenever a new theme is passed down
-  //from the parent / owner using context
-  componentWillReceiveProps(nextProps, nextContext) {
-    let newMuiTheme = nextContext.muiTheme ? nextContext.muiTheme : this.state.muiTheme;
-    this.setState({muiTheme: newMuiTheme});
   },
 
   render() {
@@ -115,7 +93,7 @@ const DatePickerDialog = React.createClass({
 
     const {
       calendarTextColor,
-    } = this.constructor.getRelevantContextKeys(this.state.muiTheme);
+    } = this.constructor.getRelevantContextKeys(this.props.muiTheme);
 
     let styles = {
       root: {
@@ -230,4 +208,4 @@ const DatePickerDialog = React.createClass({
 
 });
 
-export default DatePickerDialog;
+export default themeable(DatePickerDialog);

--- a/src/date-picker/date-picker.jsx
+++ b/src/date-picker/date-picker.jsx
@@ -4,8 +4,7 @@ import WindowListenable from '../mixins/window-listenable';
 import DateTime from '../utils/date-time';
 import DatePickerDialog from './date-picker-dialog';
 import TextField from '../text-field';
-import ThemeManager from '../styles/theme-manager';
-import DefaultRawTheme from '../styles/raw-themes/light-raw-theme';
+import themeable from '../styles/themeable-decorator';
 
 const DatePicker = React.createClass({
 
@@ -13,21 +12,6 @@ const DatePicker = React.createClass({
     StylePropable,
     WindowListenable,
   ],
-
-  contextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
-  //for passing default theme context to children
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
 
   propTypes: {
     DateTimeFormat: React.PropTypes.func,
@@ -40,6 +24,7 @@ const DatePicker = React.createClass({
     maxDate: React.PropTypes.object,
     minDate: React.PropTypes.object,
     mode: React.PropTypes.oneOf(['portrait', 'landscape']),
+    muiTheme: React.PropTypes.object.isRequired,
     onChange: React.PropTypes.func,
     onDismiss: React.PropTypes.func,
     onFocus: React.PropTypes.func,
@@ -75,7 +60,6 @@ const DatePicker = React.createClass({
     return {
       date: this._isControlled() ? this._getControlledDate() : this.props.defaultDate,
       dialogDate: new Date(),
-      muiTheme: this.context.muiTheme ? this.context.muiTheme : ThemeManager.getMuiTheme(DefaultRawTheme),
     };
   },
 
@@ -213,4 +197,4 @@ const DatePicker = React.createClass({
 
 });
 
-export default DatePicker;
+export default themeable(DatePicker);

--- a/src/mixins/style-propable.js
+++ b/src/mixins/style-propable.js
@@ -33,7 +33,8 @@ export default {
   // only call it when passing style attribute to html elements.
   // If you call it twice you'll get a warning anyway.
   prepareStyles() {
+    const muiTheme = this.props.muiTheme || (this.state && this.state.muiTheme) || this.context.muiTheme;
     return Styles.prepareStyles.apply(Styles,
-      [(this.state && this.state.muiTheme) || this.context.muiTheme].concat([].slice.apply(arguments)));
+      [muiTheme].concat([].slice.apply(arguments)));
   },
 };

--- a/src/styles/themeable-decorator.js
+++ b/src/styles/themeable-decorator.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import DefaultRawTheme from '../styles/raw-themes/dark-raw-theme';
+import ThemeManager from '../styles/theme-manager';
+
+// Putting this out here for cache-ability
+let defaultTheme;
+function getDefaultTheme() {
+  return defaultTheme || (defaultTheme = ThemeManager.getMuiTheme(DefaultRawTheme));
+}
+
+export default function(Component) {
+  const ref = 'childComponent';
+  const config = {
+    contextTypes: {
+      muiTheme: React.PropTypes.object,
+    },
+
+    childContextTypes: {
+      muiTheme: React.PropTypes.object,
+    },
+
+    getChildContext() {
+      return this.context;
+    },
+
+    render() {
+      const muiTheme = this.context.muiTheme || getDefaultTheme();
+      return React.createElement(Component, {...this.props, muiTheme, ref} );
+    },
+  };
+
+  // Create a proxy for each of the public methods
+  // the component provides in it's statics.publicMethods
+  if (Array.isArray(Component.publicMethods)) {
+    Component.publicMethods.forEach(methodName => {
+      config[methodName] = function() {
+        this.refs[ref][methodName]();
+      };
+    });
+  }
+
+  // return themed component wrapper
+  return React.createClass(config);
+}


### PR DESCRIPTION
My stab at consolidating all theme stuff used in components into one place.

- HOC to wrap components to add `muiTheme` context, or default theme if context not given
- Components themselves, once wrapped, will receive muiTheme through `props.muiTheme`.

I tried to wrap `DatePicker` and it's immediate children - `TextField`, `DatePicker`

Issues:

- `TextField` uses `StylePropable` mixin
  - Updated StylePropable to consider `this.props.muiTheme` (not really an issue)

- `DatePickerDialog` exposes public methods (`show`, `dismiss`). HOC, in it's simplest form, hides them.
  - This makes clicking on `DatePicker` input not opening the Dialog, as the `show` method is being called through `ref`
  - I had to declare `statics.publicMethods` in DatePicker, and make the HOC proxy those methods through
  - This, I think, is a cool, unintended feature - declaring which methods are public - good for documentation.

- The problem I don't have good solution for is when the components are being accessed directly for it's properties ( do we have that case?). I see `Dialog` is accessing it's children directly for height and style, but they are React components, not MUI components.
